### PR TITLE
Support shared redis instance between mrb_states

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -46,4 +46,5 @@ MRuby::Gem::Specification.new('mruby-redis') do |spec|
   spec.linker.flags_before_libraries << "#{hiredis_dir}/lib/libhiredis.a"
 
   spec.add_dependency "mruby-sleep"
+  spec.add_dependency "mruby-pointer", :github => 'matsumotory/mruby-pointer'
 end

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -103,26 +103,6 @@ static inline void mrb_redis_check_error(redisContext *context, mrb_state *mrb)
   }
 }
 
-static mrb_value mrb_redis_connect_get_raw(mrb_state *mrb, mrb_value self)
-{
-  redisContext *rc = (redisContext *)DATA_PTR(self);
-
-  if (rc) {
-    mrb_free(mrb, rc);
-  }
-  DATA_TYPE(self) = &redisContext_type;
-  DATA_PTR(self) = NULL;
-
-  rc = mrb_udptr_get(mrb);
-  if (rc->err) {
-    mrb_raise(mrb, E_REDIS_ERROR, "redis connection failed.");
-  }
-
-  DATA_PTR(self) = rc;
-
-  return self;
-}
-
 static mrb_value mrb_redis_connect_set_raw(mrb_state *mrb, mrb_value self)
 {
   redisContext *rc;
@@ -1813,7 +1793,6 @@ void mrb_mruby_redis_gem_init(mrb_state *mrb)
 
   /* use mruby-pointer for sharing between mrb_states */
   mrb_define_class_method(mrb, redis, "connect_set_raw", mrb_redis_connect_set_raw, MRB_ARGS_ANY());
-  mrb_define_class_method(mrb, redis, "connect_get_raw", mrb_redis_connect_get_raw, MRB_ARGS_ANY());
 
   mrb_define_method(mrb, redis, "auth", mrb_redis_auth, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, redis, "select", mrb_redis_select, MRB_ARGS_REQ(1));

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -43,6 +43,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include "mrb_pointer.h"
 
 #define DONE mrb_gc_arena_restore(mrb, 0);
 
@@ -100,6 +101,47 @@ static inline void mrb_redis_check_error(redisContext *context, mrb_state *mrb)
       }
     }
   }
+}
+
+static mrb_value mrb_redis_connect_get_raw(mrb_state *mrb, mrb_value self)
+{
+  redisContext *rc = (redisContext *)DATA_PTR(self);
+
+  if (rc) {
+    mrb_free(mrb, rc);
+  }
+  DATA_TYPE(self) = &redisContext_type;
+  DATA_PTR(self) = NULL;
+
+  rc = mrb_udptr_get(mrb);
+  if (rc->err) {
+    mrb_raise(mrb, E_REDIS_ERROR, "redis connection failed.");
+  }
+
+  DATA_PTR(self) = rc;
+
+  return self;
+}
+
+static mrb_value mrb_redis_connect_set_raw(mrb_state *mrb, mrb_value self)
+{
+  redisContext *rc;
+  mrb_value host, port;
+  mrb_int timeout = 1;
+  struct timeval timeout_struct = {timeout, 0};
+
+  if (mrb_get_args(mrb, "oo|i", &host, &port, &timeout) == 3) {
+    timeout_struct.tv_sec = timeout;
+  }
+
+  rc = redisConnectWithTimeout(mrb_str_to_cstr(mrb, host), mrb_fixnum(port), timeout_struct);
+  if (rc->err) {
+    mrb_raise(mrb, E_REDIS_ERROR, "redis connection failed.");
+  }
+
+  mrb_udptr_set(mrb, (void *)rc);
+
+  return self;
 }
 
 static mrb_value mrb_redis_connect(mrb_state *mrb, mrb_value self)
@@ -1761,6 +1803,11 @@ void mrb_mruby_redis_gem_init(mrb_state *mrb)
   mrb_define_class_under(mrb, redis, "AuthError", redis_error);
 
   mrb_define_method(mrb, redis, "initialize", mrb_redis_connect, MRB_ARGS_ANY());
+
+  /* use mruby-pointer for sharing between mrb_states */
+  mrb_define_class_method(mrb, redis, "connect_set_raw", mrb_redis_connect_set_raw, MRB_ARGS_ANY());
+  mrb_define_class_method(mrb, redis, "connect_get_raw", mrb_redis_connect_get_raw, MRB_ARGS_ANY());
+
   mrb_define_method(mrb, redis, "auth", mrb_redis_auth, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, redis, "select", mrb_redis_select, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, redis, "ping", mrb_redis_ping, MRB_ARGS_NONE());


### PR DESCRIPTION
See also more information: https://github.com/matsumotory/mruby-pointer


- PoC code

ref: https://github.com/matsumotory/mruby-pointer#example

```c
mrb_src = mrb_open();
mrb_dst = mrb_open();

mrb_udptr_init(mrb_src);

mrb_load_string(mrb_src, 'Redis.connect_set_raw "127.0.0.1", 6379');

mrb_udptr_copy(mrb_src, mrb_dst);

mrb_load_string(mrb_dst, 'redis = Redis.connect_get_raw; p redis["hoge"]');

mrb_udptr_free(mrb_src);
```
