### PR TITLE
Implement `SETNX`

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,15 @@ client.set key, "200"
 ```
 
 
+#### `Redis#setnx` [doc](http://redis.io/commands/setnx)
+
+```ruby
+client.setnx key, "foo" # => true
+client.setnx key, "bar" # => false
+client.get key          # => "foo"
+```
+
+
 #### `Redis#sismember` [doc](http://redis.io/commands/sismember)
 
 TBD

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -1872,6 +1872,28 @@ static mrb_value mrb_redis_unwatch(mrb_state *mrb, mrb_value self)
   return str;
 }
 
+static mrb_value mrb_redis_setnx(mrb_state *mrb, mrb_value self)
+{
+  mrb_value key, val;
+  redisContext *rc = DATA_PTR(self);
+  mrb_int integer;
+  const char *argv[3];
+  size_t lens[3];
+  redisReply *rs;
+
+  mrb_get_args(mrb, "oo", &key, &val);
+  CREATE_REDIS_COMMAND_ARG2(argv, lens, "SETNX", key, val);
+  rs = redisCommandArgv(rc, 3, argv, lens);
+  if (rc->err) {
+    mrb_redis_check_error(rc, mrb);
+  }
+  integer = rs->integer;
+  freeReplyObject(rs);
+
+  return mrb_bool_value(integer == 1);
+}
+
+
 void mrb_mruby_redis_gem_init(mrb_state *mrb)
 {
   struct RClass *redis, *redis_error;
@@ -1957,6 +1979,7 @@ void mrb_mruby_redis_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, redis, "discard", mrb_redis_discard, MRB_ARGS_NONE());
   mrb_define_method(mrb, redis, "watch", mrb_redis_watch, (MRB_ARGS_REQ(1) | MRB_ARGS_REST()));
   mrb_define_method(mrb, redis, "unwatch", mrb_redis_unwatch, MRB_ARGS_NONE());
+  mrb_define_method(mrb, redis, "setnx", mrb_redis_setnx, MRB_ARGS_REQ(2));
   DONE;
 }
 

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -58,6 +58,17 @@ assert("Redis#set, Redis#get") do
 
   assert_equal "fuga", ret
 end
+
+assert("Redis#setnx, Redis#get") do
+  r = Redis.new HOST, PORT
+  r.flushall
+  assert_true r.setnx( "hoge", "fuga")
+  assert_false r.setnx( "hoge", "piyo")
+  ret = r.get "hoge"
+
+  assert_equal "fuga", ret
+end
+
 assert("Redis#[]=, Redis#[]") do
   r = Redis.new HOST, PORT
   r["hoge"] = "fuga"


### PR DESCRIPTION
This commit adds `SETNX`. `SET` was supporting options but this command
uses the native `SETNX` call instead.

This PR addresses #86 