### PR TITLE
Better argument handling in get/set

### DIFF
--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -232,10 +232,10 @@ static mrb_value mrb_redis_set(mrb_state *mrb, mrb_value self)
 
   CREATE_REDIS_COMMAND_ARG2(argv, lens, "SET", key, val);
   if (b) {
-    mrb_value ex = mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "EX"));
-    mrb_value px = mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "PX"));
-    mrb_bool nx = mrb_bool(mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "NX")));
-    mrb_bool xx = mrb_bool(mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "XX")));
+    mrb_value ex = mrb_hash_delete_key(mrb, opt, mrb_str_new_cstr(mrb, "EX"));
+    mrb_value px = mrb_hash_delete_key(mrb, opt, mrb_str_new_cstr(mrb, "PX"));
+    mrb_bool nx = mrb_bool(mrb_hash_delete_key(mrb, opt, mrb_str_new_cstr(mrb, "NX")));
+    mrb_bool xx = mrb_bool(mrb_hash_delete_key(mrb, opt, mrb_str_new_cstr(mrb, "XX")));
 
     if (!mrb_nil_p(ex) && !mrb_nil_p(px)) {
       mrb_raise(mrb, E_ARGUMENT_ERROR, "Only one of EX or PX can be set");
@@ -285,6 +285,11 @@ static mrb_value mrb_redis_set(mrb_state *mrb, mrb_value self)
       argv[c] = "XX";
       lens[c] = strlen("XX");
       c++;
+    }
+
+    if (!mrb_bool(mrb_hash_empty_p(mrb, opt))) {
+      mrb_raisef(mrb, E_ARGUMENT_ERROR, "unknown option(s) specified %S (note: only string can be key, not the symbol",
+                 mrb_hash_keys(mrb, opt));
     }
   }
 

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -232,23 +232,28 @@ static mrb_value mrb_redis_set(mrb_state *mrb, mrb_value self)
 
   CREATE_REDIS_COMMAND_ARG2(argv, lens, "SET", key, val);
   if (b) {
-    v = mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "EX"));
-    if (!mrb_nil_p(v)) {
+    mrb_value ex = mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "EX"));
+    mrb_value px = mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "PX"));
+
+    if (!mrb_nil_p(ex) && !mrb_nil_p(px)) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "Only one of EX or PX can be set");
+    }
+
+    if (!mrb_nil_p(ex)) {
       argv[c] = "EX";
       lens[c] = strlen("EX");
       c++;
-      argv[c] = RSTRING_PTR(v);
-      lens[c] = RSTRING_LEN(v);
+      argv[c] = RSTRING_PTR(ex);
+      lens[c] = RSTRING_LEN(ex);
       c++;
     }
 
-    v = mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "PX"));
-    if (!mrb_nil_p(v)) {
+    if (!mrb_nil_p(px)) {
       argv[c] = "PX";
       lens[c] = strlen("PX");
       c++;
-      argv[c] = RSTRING_PTR(v);
-      lens[c] = RSTRING_LEN(v);
+      argv[c] = RSTRING_PTR(px);
+      lens[c] = RSTRING_LEN(px);
       c++;
     }
 

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -220,7 +220,7 @@ static mrb_value mrb_redis_select(mrb_state *mrb, mrb_value self)
 
 static mrb_value mrb_redis_set(mrb_state *mrb, mrb_value self)
 {
-  mrb_value key, val, opt, v, w;
+  mrb_value key, val, opt;
   mrb_bool b = 0;
   redisReply *rs;
   const char *argv[7];
@@ -234,9 +234,15 @@ static mrb_value mrb_redis_set(mrb_state *mrb, mrb_value self)
   if (b) {
     mrb_value ex = mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "EX"));
     mrb_value px = mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "PX"));
+    mrb_bool nx = mrb_bool(mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "NX")));
+    mrb_bool xx = mrb_bool(mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "XX")));
 
     if (!mrb_nil_p(ex) && !mrb_nil_p(px)) {
       mrb_raise(mrb, E_ARGUMENT_ERROR, "Only one of EX or PX can be set");
+    }
+
+    if (nx && xx) {
+      mrb_raise(mrb, E_ARGUMENT_ERROR, "Either NX or XX is true");
     }
 
     if (!mrb_nil_p(ex)) {
@@ -269,18 +275,13 @@ static mrb_value mrb_redis_set(mrb_state *mrb, mrb_value self)
       c++;
     }
 
-    v = mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "NX"));
-    w = mrb_hash_get(mrb, opt, mrb_str_new_cstr(mrb, "XX"));
-    if (!mrb_nil_p(v) && !mrb_nil_p(w)) {
-      mrb_raise(mrb, E_ARGUMENT_ERROR, "Either NX or XX is true");
-    }
-    if (!mrb_nil_p(v)) {
+    if (nx) {
       argv[c] = "NX";
       lens[c] = strlen("NX");
       c++;
     }
 
-    if (!mrb_nil_p(w)) {
+    if (xx) {
       argv[c] = "XX";
       lens[c] = strlen("XX");
       c++;

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -243,6 +243,12 @@ static mrb_value mrb_redis_set(mrb_state *mrb, mrb_value self)
       argv[c] = "EX";
       lens[c] = strlen("EX");
       c++;
+      if (mrb_fixnum_p(ex)) {
+        ex = mrb_fixnum_to_str(mrb, ex, 10);
+      }
+      if (!mrb_string_p(ex)) {
+        mrb_raisef(mrb, E_TYPE_ERROR, "EX should be int or str, but %S given", ex);
+      }
       argv[c] = RSTRING_PTR(ex);
       lens[c] = RSTRING_LEN(ex);
       c++;
@@ -252,6 +258,12 @@ static mrb_value mrb_redis_set(mrb_state *mrb, mrb_value self)
       argv[c] = "PX";
       lens[c] = strlen("PX");
       c++;
+      if (mrb_fixnum_p(px)) {
+        px = mrb_fixnum_to_str(mrb, px, 10);
+      }
+      if (!mrb_string_p(px)) {
+        mrb_raisef(mrb, E_TYPE_ERROR, "PX should be int or str, but %S given", px);
+      }
       argv[c] = RSTRING_PTR(px);
       lens[c] = RSTRING_LEN(px);
       c++;

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -228,7 +228,7 @@ static mrb_value mrb_redis_set(mrb_state *mrb, mrb_value self)
   int c = 3;
   redisContext *rc = DATA_PTR(self);
 
-  mrb_get_args(mrb, "oo|H?", &key, &val, &opt, &b);
+  mrb_get_args(mrb, "SS|H?", &key, &val, &opt, &b);
 
   CREATE_REDIS_COMMAND_ARG2(argv, lens, "SET", key, val);
   if (b) {
@@ -287,7 +287,7 @@ static mrb_value mrb_redis_get(mrb_state *mrb, mrb_value self)
   size_t lens[2];
   redisReply *rs;
 
-  mrb_get_args(mrb, "o", &key);
+  mrb_get_args(mrb, "S", &key);
 
   CREATE_REDIS_COMMAND_ARG1(argv, lens, "GET", key);
 

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -67,6 +67,13 @@ assert("Redis#set, Redis#get") do
   assert_equal "fuga", ret
 end
 
+assert("Redis#set with conflict opts") do
+  r = Redis.new HOST, PORT
+  assert_raise(ArgumentError){ r.set( "hoge", "fuga", "EX" => 1, "PX" => 100)}
+  assert_raise(ArgumentError){ r.set( "hoge", "fuga", "NX" => true, "XX" => true)}
+  r.close
+end
+
 assert("Redis#setnx, Redis#get") do
   r = Redis.new HOST, PORT
   r.flushall

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -78,6 +78,16 @@ assert("Redis#set with PX as int") do
   assert_true 0 < ttl && ttl <= 10
 end
 
+assert("Redis#set with both NX and XX") do
+  r = Redis.new HOST, PORT
+  r.set( "hoge", "fuga")
+  r.set( "hoge", "fuga with both NX and XX", "NX" => false, "XX" => true)
+  ret = r.get "hoge"
+  r.close
+
+  assert_equal "fuga with both NX and XX", ret
+end
+
 assert("Redis#set with conflict opts") do
   r = Redis.new HOST, PORT
   assert_raise(ArgumentError){ r.set( "hoge", "fuga", "EX" => 1, "PX" => 100)}

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -95,6 +95,12 @@ assert("Redis#set with conflict opts") do
   r.close
 end
 
+assert("Redis#set with unknown keys") do
+  r = Redis.new HOST, PORT
+  assert_raise(ArgumentError){ r.set( "hoge", "fuga", :EX => 100)}
+  r.close
+end
+
 assert("Redis#setnx, Redis#get") do
   r = Redis.new HOST, PORT
   r.flushall

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -67,6 +67,17 @@ assert("Redis#set, Redis#get") do
   assert_equal "fuga", ret
 end
 
+assert("Redis#set with PX as int") do
+  r = Redis.new HOST, PORT
+  r.set( "hoge", "fuga with PX as int", "PX" => 10_000)
+  ret = r.get "hoge"
+  ttl = r.ttl "hoge"
+  r.close
+
+  assert_equal "fuga with PX as int", ret
+  assert_true 0 < ttl && ttl <= 10
+end
+
 assert("Redis#set with conflict opts") do
   r = Redis.new HOST, PORT
   assert_raise(ArgumentError){ r.set( "hoge", "fuga", "EX" => 1, "PX" => 100)}

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -49,22 +49,10 @@ assert("Redis#set, Redis#get for non-string") do
   r.close
 end
 
-assert("Redis#set, Redis#get") do
+assert("Redis#set with invalid args") do
   r = Redis.new HOST, PORT
-  r.set( "hoge", "fuga", {EX: "10", PX: "1"})
-  ret = r.get "hoge"
+  assert_raise(ArgumentError){r.set( "hoge", "fuga", {EX: "10", PX: "1"})}
   r.close
-
-  assert_equal "fuga", ret
-end
-
-assert("Redis#set, Redis#get") do
-  r = Redis.new HOST, PORT
-  r.set( "hoge", "fuga", {EX: "10", PX: "1"})
-  ret = r.get "hoge"
-  r.close
-
-  assert_equal "fuga", ret
 end
 
 assert("Redis#set with PX as int") do

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -41,6 +41,14 @@ assert("Redis#set, Redis#get") do
   assert_equal "fuga", ret
 end
 
+assert("Redis#set, Redis#get for non-string") do
+  r = Redis.new HOST, PORT
+  assert_raise(TypeError) {r.set :hoge, 'bar'}
+  assert_raise(TypeError) {r.set 'hoge', 10}
+  assert_raise(TypeError) {r.get :hoge}
+  r.close
+end
+
 assert("Redis#set, Redis#get") do
   r = Redis.new HOST, PORT
   r.set( "hoge", "fuga", {EX: "10", PX: "1"})


### PR DESCRIPTION
# What's changed

I've enhanced argument handling. Currently only `get`/`set` methods are scoped, but can be applied to another methods if this fix works good.

I've done several changes, so seeing separate commits might be more review-friendly :wink:

To be honest, I'm wondering if there were any performance issue that you avoid those handling...:thinking:

## Raise `TypeError` in `mrb_redis_get`/`set` for non-string argument 1018dcb

If you pass non-string value as key and/or value in `get`/`set` method,

**Before:** Segfault :boom:
:point_down:
**After:** Raises `TypeError` :white_check_mark:

But of course, there are some other choices that I can do:

- Convert everything to string instead of raising error
- Convert symbol to string only for key, and raise error otherwise
- Convert symbol to string only for key, convert everything to string for value, and raise error otherwise
- ...etc

## Raise `ArgumentError` if both `EX` & `PX` specified in `mrb_redis_set` 19e0d5a

If you specified both `EX` and `PX` in `set` method,

**Before:** Set failed, without any response nor exception :boom:
:point_down:
**After:** Raises `ArgumentError` :white_check_mark:

Concerning to this problem, I will open a new issue that proposes to change return type of `set` method.

## Allow `EX` & `PX` to be int in `mrb_redis_set` a15afe9

If you specified `EX` or `PX` as non-string in `set` method,

**Before:** Segfault :boom:
:point_down:
**After:** Success if type is `Fixnum`, and Raises `TypeError` otherwise :white_check_mark:

Again, there're some other choices:

- Convert everything to int (then to string)
- Convert float to int (then to string) and raise error otherwise
- ...etc

## Allow to specify both `NX` & `XX` in `mrb_redis_set` 29fb5bc

If you specify `NX` as truthy value and `XX` as falsy value at the same time (or vice-versa) in `set` method,

**Before:** Raise `ArgumentError` :boom:
:point_down:
**After:** Success to set :white_check_mark:

Of course "truthy-and-truthy" will cause error as previous.

## Raise ArgumentError if unknown keys specified for `mrb_redis_set` a5c11a2, 6e2bda7

If you specify unknown key for `set` method (including `EX` etc as symbol),

**Before:** Those arguments are ignored :boom:
:point_down:
**After:** Raise `ArgumentError` :white_check_mark:

Again I have another choice; which is to support symbol as option key.

Alongside this fix, I also fixed some test in 6e2bda7.