### PR TITLE
Refactor for safer method call and consistent return value

### DIFF
--- a/include/mruby/redis.h
+++ b/include/mruby/redis.h
@@ -15,6 +15,7 @@ extern "C" {
 #define E_REDIS_ERR_PROTOCOL (mrb_class_get_under(mrb, mrb_class_get(mrb, "Redis"), "ProtocolError"))
 #define E_REDIS_ERR_OOM (mrb_class_get_under(mrb, mrb_class_get(mrb, "Redis"), "OOMError"))
 #define E_REDIS_ERR_AUTH (mrb_class_get_under(mrb, mrb_class_get(mrb, "Redis"), "AuthError"))
+#define E_REDIS_ERR_CLOSED (mrb_class_get_under(mrb, mrb_class_get(mrb, "Redis"), "ClosedError"))
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
# Overview

This fixes #89, but actually it's more drastic change on how the methods call Redis commands.

Previously, each method is implemented independently and do type check, error check or reply conversion on its own responsibility.
Therefore, there exists inconsistency between methods, and some can't handle error well nor return appropriate reply.

Here, I refactored it, and almost all methods utilize same common methods to build command and execute it.

# Details

### Common utility methods

Here's the list of "common methods" (See b63a6707e179d983b95e2118990bea1b5216df5e for more details):

- `mrb_redis_create_command_...`
    - Build redis command by parsing args. It's like `CREATE_REDIS_COMMAND_ARGX` macro, but do more (it uses the macro inside).
    - Following methods don't use this due to optional arguments:`set`, `hmget`, `hmset`, `mget`, `mset`, `watch`, `sadd`, `srem`, `pfcount`, `pfadd`, `pfmerge`
- `mrb_redis_get_context`
    - Get `RedisContext` and check if it's not NULL (a thin wrapper around `DATA_PTR(self);`).
- `mrb_redis_execute_command`
    - Execute built command and return reply as `mrb_value` (or raise exception if any). This uses `mrb_redis_get_context` inside.
    - Following methods don't use this due to its unique error handling (raise `ArgumentError`): `hmget`, `hmset`, `mget`, `mset`,

Note that `queue`, `reply` and `bulk_reply` method is left as is (except for utilizing `mrb_redis_get_context`), because they have totally inconsistent interfaces with other methods.

### Problems solved

There area 3 problems solved by this PR:

1. `"Closed context"` Operation over closed context
    - :boom: **Before** SEGV → :white_check_mark: **After** Raise `Redis::ClosedError`
2. `"Error reply"`: If error reply returned
    - :boom: **Before** Depends on each method → :white_check_mark: **After** Raise `Redis::ReplyError`
3. `"Type safety"`: If invalid type is given as argument
    - :boom: **Before** SEGV → :white_check_mark: **After** Raise `TypeError`
4. `"Return self"`: In normal usage of some methods
    - :boom: **Before** Return self → :white_check_mark: **After** Return redis's reply

Here's the full list of changes.

- :heavy_check_mark:: Problem will be fixed.
- "out of scope": Problem exists, but it's out of scope of this PR.
- Blank: It's ok, problem does not exists.

| Method      | Closed context     | Error reply                               | Type safety                                           | Return self                      |
| :---------- | :----------------- | :---------------------------------------- | :---------------------------------------------------- | :------------------------------- |
| `ping`      | :heavy_check_mark: | :heavy_check_mark: (before: error as str) |                                                       |                                  |
| `auth`      | :heavy_check_mark: |                                           | :heavy_check_mark: (used to raise `Redis::AuthError`) | :heavy_check_mark: -> "OK"       |
| `select`    | :heavy_check_mark: | :heavy_check_mark: (before: `self`)       |                                                       | :heavy_check_mark: -> "OK"       |
| `set`       | :heavy_check_mark: | :heavy_check_mark: (before: `self`)       |                                                       | :heavy_check_mark: -> "OK"/`nil` |
| `get`       | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        |                                                       |                                  |
| `keys`      | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `exists`    | :heavy_check_mark: | :heavy_check_mark: (before: `false`)      | :heavy_check_mark:                                    |                                  |
| `expire`    | :heavy_check_mark: | :heavy_check_mark: (before: `false`)      | :heavy_check_mark:                                    |                                  |
| `flushdb`   | :heavy_check_mark: | :heavy_check_mark: (before: error as str) |                                                       |                                  |
| `flushall`  | :heavy_check_mark: | :heavy_check_mark: (before: error as str) |                                                       |                                  |
| `randomkey` | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        |                                                       |                                  |
| `del`       | :heavy_check_mark: | :heavy_check_mark: (before: `self`)       | :heavy_check_mark:                                    | :heavy_check_mark: -> int        |
| `incr`      | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `decr`      | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `incrby`    | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `decrby`    | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `llen`      | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `rpush`     | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `lpush`     | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `rpop`      | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `lpop`      | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `lrange`    | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `ltrim`     | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `lindex`    | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `sadd`      | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | (out of scope)                                        |                                  |
| `srem`      | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | (out of scope)                                        |                                  |
| `sismember` | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `smembers`  | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `scard`     | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `scard`     | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `hset`      | :heavy_check_mark: | :heavy_check_mark: (before: `false`)      | :heavy_check_mark:                                    |                                  |
| `hsetnx`    | :heavy_check_mark: | :heavy_check_mark: (before: `false`)      | :heavy_check_mark:                                    |                                  |
| `hget`      | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `hgetall`   | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `hdel`      | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `hexists`   | :heavy_check_mark: | :heavy_check_mark: (before: `false`)      | :heavy_check_mark:                                    |                                  |
| `hexists`   | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `hmget`     | :heavy_check_mark: | (out of scope)                            |                                                       |                                  |
| `hmset`     | :heavy_check_mark: | (out of scope)                            |                                                       |                                  |
| `hvals`     | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `hincrby`   | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `mget`      | :heavy_check_mark: | (out of scope)                            |                                                       |                                  |
| `mset`      | :heavy_check_mark: | (out of scope)                            |                                                       |                                  |
| `ttl`       | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `zadd`      | :heavy_check_mark: | :heavy_check_mark: (before: `self`)       | :heavy_check_mark:                                    | :heavy_check_mark: -> int        |
| `zcard`     | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `zrange`    | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `zrevrange` | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `zrank`     | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `zrevrank`  | :heavy_check_mark: | :heavy_check_mark: (before: 0)            | :heavy_check_mark:                                    |                                  |
| `zscore`    | :heavy_check_mark: | :heavy_check_mark: (before: error as str) | :heavy_check_mark:                                    |                                  |
| `pub`       | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        | :heavy_check_mark:                                    |                                  |
| `pfadd`     | :heavy_check_mark: | ✔️ (before: 0)                             | (out of scope)                                        |                                  |
| `pfcount`   | :heavy_check_mark: | ✔️ (before: 0)                             | (out of scope)                                        |                                  |
| `pfmerge`   | :heavy_check_mark: | ✔️ (before: `nil`)                         | (out of scope)                                        |                                  |
| `queue`     | :heavy_check_mark: |                                           |                                                       | OK                               |
| `reply`     | :heavy_check_mark: | (out of scope)                            |                                                       |                                  |
| `bulkreply` | :heavy_check_mark: | (out of scope)                            |                                                       |                                  |
| `multi`     | :heavy_check_mark: | :heavy_check_mark: (before: error as str) |                                                       |                                  |
| `exec`      | :heavy_check_mark: | :heavy_check_mark: (before: `nil`)        |                                                       |                                  |
| `discard`   | :heavy_check_mark: | :heavy_check_mark: (before: error as str) |                                                       |                                  |
| `watch`     | :heavy_check_mark: | ✔️ (before: error as str)                  |                                                       |                                  |
| `unwatch`   | :heavy_check_mark: | :heavy_check_mark: (before: error as str) |                                                       |                                  |
| `setnx`     | :heavy_check_mark: | :heavy_check_mark: (before: `false`)      | :heavy_check_mark:                                    |                                  |

# Review points

Sorry for the huge diff, I picked up some points to focus on.

1. Design of common method (and its usage) is good?
2. Backward incompatible changes are affordable?
    - 1st and 3rd problem shown in above table is about SEGV so I think there's no room to discuss. But 2nd and 4th ones bring backward-incompatible breaking changes to the library (4th one is what I proposed in #89).
    - IMO, it's affordable *IF* library version is managed appropriately.
