### PR TITLE
Add support of TCP keepalive

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ client.host                             # => "127.0.0.1"
 client.port                             # => 6379
 client.select 0                         # Select the database
 client.auth "secret"                    # Required if Redis is password-protected
+client.enable_keepalive                 # Turn on TCP keepalive if needed
+client.keepalive                        # => :on
 ```
 
 ### Commands

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -47,4 +47,6 @@ MRuby::Gem::Specification.new('mruby-redis') do |spec|
 
   spec.add_dependency "mruby-sleep"
   spec.add_dependency "mruby-pointer", :github => 'matsumotory/mruby-pointer'
+  spec.add_test_dependency "mruby-open3"
+  spec.add_test_dependency "mruby-onig-regexp"
 end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -47,6 +47,4 @@ MRuby::Gem::Specification.new('mruby-redis') do |spec|
 
   spec.add_dependency "mruby-sleep"
   spec.add_dependency "mruby-pointer", :github => 'matsumotory/mruby-pointer'
-  spec.add_test_dependency "mruby-open3"
-  spec.add_test_dependency "mruby-onig-regexp"
 end

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -183,7 +183,27 @@ static mrb_value mrb_redis_connect(mrb_state *mrb, mrb_value self)
 
   DATA_PTR(self) = rc;
 
+  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "keepalive"), mrb_symbol_value(mrb_intern_lit(mrb, "off")));
+
   return self;
+}
+
+static mrb_value mrb_redis_enable_keepalive(mrb_state *mrb, mrb_value self)
+{
+  redisContext *rc = mrb_redis_get_context(mrb, self);
+  errno = 0;
+  if (redisEnableKeepAlive(rc) == REDIS_OK) {
+    mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "keepalive"), mrb_symbol_value(mrb_intern_lit(mrb, "on")));
+  } else {
+    mrb_sys_fail(mrb, rc->errstr);
+  }
+  return mrb_nil_value();
+}
+
+static mrb_value mrb_redis_keepalive(mrb_state *mrb, mrb_value self)
+{
+  mrb_redis_get_context(mrb, self); // Check if closed
+  return mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "keepalive"));
 }
 
 static mrb_value mrb_redis_host(mrb_state *mrb, mrb_value self)
@@ -1438,6 +1458,8 @@ void mrb_mruby_redis_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, redis, "connect_set_raw", mrb_redis_connect_set_raw, MRB_ARGS_ANY());
   mrb_define_class_method(mrb, redis, "connect_set_udptr", mrb_redis_connect_set_raw, MRB_ARGS_ANY());
 
+  mrb_define_method(mrb, redis, "enable_keepalive", mrb_redis_enable_keepalive, MRB_ARGS_NONE());
+  mrb_define_method(mrb, redis, "keepalive", mrb_redis_keepalive, MRB_ARGS_NONE());
   mrb_define_method(mrb, redis, "auth", mrb_redis_auth, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, redis, "select", mrb_redis_select, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, redis, "ping", mrb_redis_ping, MRB_ARGS_NONE());

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -21,6 +21,21 @@ assert("Non-authrozied Redis#ping") do
   r.close
 end
 
+assert("Redis#enable_keepalive, Redis#keepalive") do
+  r = Redis.new HOST, PORT
+
+  assert_equal :off, r.keepalive
+  assert_nil r.enable_keepalive
+  assert_equal :on, r.keepalive
+
+  stdout, _, _ = Open3.capture3('lsof', '-a', '-cmrbtest', '-i:6379', '-Tf', '-FT')
+  assert_true /^TSO.*KEEPALIVE/ =~ stdout
+
+  r.close
+  assert_raise(Redis::ClosedError) {r.keepalive}
+  assert_raise(Redis::ClosedError) {r.enable_keepalive}
+end
+
 assert("Redis#host, Redis#port") do
   r = Redis.new HOST, PORT
 

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -28,9 +28,6 @@ assert("Redis#enable_keepalive, Redis#keepalive") do
   assert_nil r.enable_keepalive
   assert_equal :on, r.keepalive
 
-  stdout, _, _ = Open3.capture3('lsof', '-a', '-cmrbtest', '-i:6379', '-Tf', '-FT')
-  assert_true /^TSO.*KEEPALIVE/ =~ stdout
-
   r.close
   assert_raise(Redis::ClosedError) {r.keepalive}
   assert_raise(Redis::ClosedError) {r.enable_keepalive}


### PR DESCRIPTION
 ```ruby
 client = Redis.new 'localhost', 6379
# Turn on TCP keepalive if needed
client.enable_keepalive
client.keepalive # => :on
 ```

Note that we don't support disabling keepalive, simply because hiredis doesn't.

(This is the last one of my series of PRs 😉)