### PR TITLE
Remove -fPIE option from cc.flags

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -30,7 +30,7 @@ MRuby::Gem::Specification.new('mruby-redis') do |spec|
   if ! File.exists? "#{hiredis_dir}/libhiredis.a"
     Dir.chdir hiredis_dir do
       e = {
-        'CC' => "#{spec.build.cc.command} #{spec.build.cc.flags.join(' ')}",
+        'CC' => "#{spec.build.cc.command} #{spec.build.cc.flags.reject {|flag| flag == '-fPIE'}.join(' ')}",
         'CXX' => "#{spec.build.cxx.command} #{spec.build.cxx.flags.join(' ')}",
         'LD' => "#{spec.build.linker.command} #{spec.build.linker.flags.join(' ')}",
         'AR' => spec.build.archiver.command,


### PR DESCRIPTION
Remove `-fPIE` option from `cc.flags` to prevent from link error while building hiredis.

We build ngx_mruby with `-fPIE` option to embed to nginx built with `-pie` option. But passing `-fPIE` option causes link error when creating shared library (`libhiredis.so`) with `-shared` option using older version of gcc like gcc 4.4.