### PR TITLE
Support Redis#cluster and Redis#asking methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
       - bison
       - git
       - gperf
+      - redis-server
 language: c
 compiler:
   - gcc
@@ -13,6 +14,13 @@ compiler:
 before_script:
   - redis-server --port 6379 &
   - redis-server --port 6380 --requirepass 'secret' &
+  - redis-server --cluster-enabled yes --cluster-config-file 7000-nodes.conf --port 7000 &
+  - redis-server --cluster-enabled yes --cluster-config-file 7001-nodes.conf --port 7001 &
+  - redis-server --cluster-enabled yes --cluster-config-file 7002-nodes.conf --port 7002 &
+  - redis-server --cluster-enabled yes --cluster-config-file 7003-nodes.conf --port 7003 &
+  - redis-server --cluster-enabled yes --cluster-config-file 7004-nodes.conf --port 7004 &
+  - redis-server --cluster-enabled yes --cluster-config-file 7005-nodes.conf --port 7005 &
+  - echo yes | redis-cli --cluster create 127.0.0.1:7000 127.0.0.1:7001 127.0.0.1:7002 127.0.0.1:7003 127.0.0.1:7004 127.0.0.1:7005
 script:
   - rake test
 notifications:

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ client.keepalive                        # => :on
 client.auth "secret"
 ```
 
+#### `Redis#asking`
+
+```ruby
+client.asking
+```
+
+
 #### `Redis#[]=`
 
 TBD
@@ -72,6 +79,15 @@ TBD
 #### `Redis#close`
 
 TBD
+
+
+#### `Redis#cluster` [doc](http://redis.io/commands/cluster-info)
+
+```ruby
+client.cluster "info"
+client.cluster "nodes"
+client.cluster "slots"
+```
 
 
 #### `Redis#decr` [doc](http://redis.io/commands/decr)

--- a/src/mrb_redis.c
+++ b/src/mrb_redis.c
@@ -1348,6 +1348,24 @@ static mrb_value mrb_redis_setnx(mrb_state *mrb, mrb_value self)
   return mrb_redis_execute_command(mrb, self, argc, argv, lens, &rule);
 }
 
+static mrb_value mrb_redis_cluster(mrb_state *mrb, mrb_value self)
+{
+  const char *argv[2];
+  size_t lens[2];
+  int argc = mrb_redis_create_command_str(mrb, "CLUSTER", argv, lens);
+  ReplyHandlingRule rule = DEFAULT_REPLY_HANDLING_RULE;
+  return mrb_redis_execute_command(mrb, self, argc, argv, lens, &rule);
+}
+
+static mrb_value mrb_redis_asking(mrb_state *mrb, mrb_value self)
+{
+  const char *argv[1];
+  size_t lens[1];
+  int argc = mrb_redis_create_command_noarg(mrb, "ASKING", argv, lens);
+  ReplyHandlingRule rule = DEFAULT_REPLY_HANDLING_RULE;
+  return mrb_redis_execute_command(mrb, self, argc, argv, lens, &rule);
+}
+
 static inline int mrb_redis_create_command_noarg(mrb_state *mrb, const char *cmd, const char **argv, size_t *lens)
 {
   argv[0] = cmd;
@@ -1541,6 +1559,8 @@ void mrb_mruby_redis_gem_init(mrb_state *mrb)
   mrb_define_method(mrb, redis, "watch", mrb_redis_watch, (MRB_ARGS_REQ(1) | MRB_ARGS_REST()));
   mrb_define_method(mrb, redis, "unwatch", mrb_redis_unwatch, MRB_ARGS_NONE());
   mrb_define_method(mrb, redis, "setnx", mrb_redis_setnx, MRB_ARGS_REQ(2));
+  mrb_define_method(mrb, redis, "cluster", mrb_redis_cluster, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, redis, "asking", mrb_redis_asking, MRB_ARGS_NONE());
   DONE;
 }
 

--- a/test/redis.rb
+++ b/test/redis.rb
@@ -5,6 +5,8 @@
 HOST         = "127.0.0.1"
 PORT         = 6379
 SECURED_PORT = 6380
+CLUSTER_PORT = 7000
+NUM_OF_CLUSTER_NODES = 6
 
 assert("Redis#ping") do
   r = Redis.new HOST, PORT
@@ -1432,4 +1434,28 @@ assert("Error handling") do
           false
         end
   assert_true res
+end
+
+assert("Redis#asking") do
+  r = Redis.new HOST, CLUSTER_PORT
+  assert_equal "OK", r.asking
+  r.close
+  assert_raise(Redis::ClosedError) {r.asking}
+end
+
+assert("Redis#cluster") do
+  r = Redis.new HOST, CLUSTER_PORT
+  nodes = r.cluster "nodes"
+  slots = r.cluster "slots"
+
+  assert_kind_of(String, nodes)
+  assert_equal NUM_OF_CLUSTER_NODES, nodes.split("\n").length
+  assert_kind_of(Array, slots)
+  assert_equal NUM_OF_CLUSTER_NODES, slots.length
+
+  assert_raise(Redis::ArgumentError) {r.cluster}
+  assert_raise(TypeError) {r.cluster nil}
+
+  r.close
+  assert_raise(Redis::ClosedError) {r.cluster "info"}
 end


### PR DESCRIPTION
This PR adds Redis#cluster and Redis#asking methods.
It allows sending commands for [Redis Cluster](https://redis.io/topics/cluster-spec) (e.g. [CLUSTER NODES](https://redis.io/commands/cluster-nodes), [CLUSTER SLOTS](https://redis.io/commands/cluster-slots), etc.).