### PR TITLE
Make this build on *BSD.

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -36,9 +36,9 @@ MRuby::Gem::Specification.new('mruby-redis') do |spec|
         'AR' => spec.build.archiver.command,
         'PREFIX' => hiredis_dir
       }
-
-      run_command e, "make"
-      run_command e, "make install"
+      make_command = `uname` =~ /BSD/ ? "gmake" : "make"
+      run_command e, "#{make_command}"
+      run_command e, "#{make_command} install"
     end
   end
 


### PR DESCRIPTION
BSD make is not GNU make. I get the following errors on NetBSD.

```
build: [exec] make
make[1]: "/home/vagrant/ngx_mruby/mruby/build/host/mrbgems/mruby-redis/hiredis/Makefile" line 30: Need an operator
make[1]: "/home/vagrant/ngx_mruby/mruby/build/host/mrbgems/mruby-redis/hiredis/Makefile" line 36: Need an operator
make[1]: "/home/vagrant/ngx_mruby/mruby/build/host/mrbgems/mruby-redis/hiredis/Makefile" line 37: Variable/Value missing from "export"
make[1]: "/home/vagrant/ngx_mruby/mruby/build/host/mrbgems/mruby-redis/hiredis/Makefile" line 62: Missing dependency operator
make[1]: "/home/vagrant/ngx_mruby/mruby/build/host/mrbgems/mruby-redis/hiredis/Makefile" line 73: Need an operator
make[1]: "/home/vagrant/ngx_mruby/mruby/build/host/mrbgems/mruby-redis/hiredis/Makefile" line 75: Missing dependency operator

[snip]

```

