### PR TITLE
Change the protocol used to download hiredis from git to https

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -21,7 +21,7 @@ MRuby::Gem::Specification.new('mruby-redis') do |spec|
   if ! File.exists? hiredis_dir
     Dir.chdir(build_dir) do
       e = {}
-      run_command e, 'git clone git://github.com/redis/hiredis.git'
+      run_command e, 'git clone https://github.com/redis/hiredis.git'
       # Latest HIREDIS is not compatible for OS X
       run_command e, "git --git-dir=#{hiredis_dir}/.git --work-tree=#{hiredis_dir} checkout v0.13.3" if `uname` =~ /Darwin/
     end


### PR DESCRIPTION
When we ran the build with `matsumotory/mruby-redis` included, it failed with the error message.

```
#32 34.94 build: [exec] git clone git://github.com/redis/hiredis.git
#32 35.35 fatal: remote error:
#32 35.35   The unauthenticated git protocol on port 9418 is no longer supported.
#32 35.35 Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
#32 35.35 Cloning into 'hiredis'...
#32 35.36 rake aborted!
#32 35.36 git clone git://github.com/redis/hiredis.git failed
#32 35.36
#32 35.36 (See full trace by running task with --trace)
#32 35.39 make: *** [build_mruby] Error 1
```

This is due to the git protocol (`git://`) used in the command to download redis/hiredis.

https://github.com/matsumotory/mruby-redis/blob/f1f98d9450783b8c281b5064554b12bfb9f0a65a/mrbgem.rake#L24

GitHub.com expressed security concerns about the git protocol and made changes on March 15.

https://github.blog/2021-09-01-improving-git-protocol-security-github/

> The deprecated MACs, ciphers, and unencrypted Git protocol will be permanently disabled.

So change the protocol used to download hiredis from git to https.

